### PR TITLE
Fix build issues with DS gradle plugin (devsoap/gradle-vaadin-flow#286)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     kotlin("jvm") version "1.3.50"
     id("org.gretty") version "2.3.1"
     war
-    id("com.devsoap.vaadin-flow") version "1.2"
+    id("com.devsoap.vaadin-flow") version "1.3.beta2"
 }
 
 vaadin {
@@ -17,13 +17,12 @@ vaadin {
 defaultTasks("clean", "build")
 
 repositories {
-    jcenter()
-    maven { setUrl("https://maven.vaadin.com/vaadin-prereleases/") }
+    vaadin.repositories()
+    vaadin.prereleases()
 }
 
 gretty {
     contextPath = "/"
-    servletContainer = "jetty9.4"
 }
 
 tasks.withType<Test> {
@@ -41,13 +40,12 @@ dependencies {
     compile("com.github.mvysny.karibudsl:karibu-dsl-v10:$karibudsl_version")
 
     // Vaadin 14
-    compile("com.vaadin:vaadin-core:${vaadin.version}")
-    compile("com.vaadin:flow-server-compatibility-mode:2.0.10")
-    providedCompile("javax.servlet:javax.servlet-api:3.1.0")
+    compile(vaadin.bom())
+    compile(vaadin.core())
 
     // logging
     // currently we are logging through the SLF4J API to SLF4J-Simple. See src/main/resources/simplelogger.properties file for the logger configuration
-    compile("org.slf4j:slf4j-simple:1.7.28")
+    compile(vaadin.slf4j())
 
     compile(kotlin("stdlib-jdk8"))
 

--- a/frontend/src/README
+++ b/frontend/src/README
@@ -1,1 +1,0 @@
-Place your Vaadin Designer or hand written templates in this folder.

--- a/src/main/javascript/README
+++ b/src/main/javascript/README
@@ -1,0 +1,1 @@
+Place your Vaadin Designer or hand written Javascript templates in this folder.

--- a/src/main/stylesheets/README
+++ b/src/main/stylesheets/README
@@ -1,3 +1,3 @@
-Place your optional styles in this folder.
+Place your optional CSS styles in this folder.
 
 See https://vaadin.com/docs/flow/theme/theming-overview.html for getting started on theming Vaadin Flow applications.


### PR DESCRIPTION
This PR fixes the current build issues with the project.

Since NPM/Polymer 3 support is a DS PRO feature, you will need to get a DS PRO license to run the project.

You can add your credentials either at runtime with a system property like so:
```bash
./gradlew \
      -Ddevsoap.gradle-flow-plugin.license.email=<YOUR LICENSE EMAIL ADDRESS> \
      -Ddevsoap.gradle-flow-plugin.license.key=<YOUR LICENSE KEY> \
      jettyRun
```

or you can add the following to build.gradle.kts:
```kotlin
devsoap {
    email = "<YOUR LICENSE EMAIL ADDRESS>"
    key = "<YOUR LICENSE KEY>"
}
```
